### PR TITLE
Python 2x compatible

### DIFF
--- a/erlastic/__init__.py
+++ b/erlastic/__init__.py
@@ -1,4 +1,6 @@
 """Erlang External Term Format serializer/deserializer"""
+import struct
+import sys
 
 from erlastic.codec import ErlangTermDecoder, ErlangTermEncoder
 from erlastic.types import *
@@ -6,23 +8,24 @@ from erlastic.types import *
 encode = ErlangTermEncoder().encode
 decode = ErlangTermDecoder().decode
 
-import struct
-import sys
 
 def mailbox_gen():
-  while True:
-    len_bin = sys.stdin.buffer.read(4)
-    if len(len_bin) != 4: return
-    (length,) = struct.unpack('!I',len_bin)
-    yield decode(sys.stdin.buffer.read(length))
+    while True:
+        len_bin = sys.stdin.buffer.read(4)
+        if len(len_bin) != 4:
+            return
+        (length,) = struct.unpack('!I', len_bin)
+        yield decode(sys.stdin.buffer.read(length))
+
 
 def port_gen():
-  while True:
-    term = encode((yield))
-    sys.stdout.buffer.write(struct.pack('!I',len(term)))
-    sys.stdout.buffer.write(term)
+    while True:
+        term = encode((yield))
+        sys.stdout.buffer.write(struct.pack('!I', len(term)))
+        sys.stdout.buffer.write(term)
+
 
 def port_connection():
-  port = port_gen()
-  next(port)
-  return mailbox_gen(),port
+    port = port_gen()
+    next(port)
+    return mailbox_gen(), port


### PR DESCRIPTION
The buffer object isn't available in python 2.x, falling back to use just sys.sdtin/out for read/write.

Also made pep8 changes.
